### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ will faithfully pipe from your build via the checks API. For example, this scrip
 
 can be reported via:
 
-```
+```yml
   - label: Pytest
     command: test.sh
     plugins:
-      uw-ipd/github-checks#v0.0.2:
-        output_title: pytest
-        output_summary: pytest_summary.md
+      - uw-ipd/github-checks#v0.0.2:
+          output_title: pytest
+          output_summary: pytest_summary.md
 ```
 
 See this plugin's [pipeline.yml](.buildkite/pipeline.yml) and


### PR DESCRIPTION
Hi again @asford 😊

(This is the same as https://github.com/uw-ipd/rsync-buildkite-plugin/pull/2, but I'm not sure which one you'll get to first, so here's all the info again!)

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.