### PR TITLE
fix typing.Union to be compatiable with python3.7 and below

### DIFF
--- a/ghapp/ghapp/cattrs.py
+++ b/ghapp/ghapp/cattrs.py
@@ -50,14 +50,17 @@ def _register_ignore_optional_none(cls, converter=None):
         raise TypeError("class does not have attrs: %s" % cls)
 
     prev_unstructure = converter._unstructure_func.dispatch(cls)
-    optional_attrs = {
-        f.name for f in attr.fields(cls)
-        if sys.version_info[0] <= 3 and sys.version_info[1] < 7:
+    if (sys.version_info[0] <= 3) and (sys.version_info[1] < 7):
+        optional_attrs = {
+            f.name for f in attr.fields(cls)
             if isinstance(f.type, typing._Union) and type(None) in f.type.__args__
-        else:
+        }
+    else:
+        optional_attrs = {
+            f.name for f in attr.fields(cls)
             if isinstance(f.type, typing._GenericAlias) and type(None) in f.type.__args__
-            
-    }
+
+        }
 
     def unstructure_ignoring_optional_none(obj):
         unstructured = prev_unstructure(obj)

--- a/ghapp/ghapp/cattrs.py
+++ b/ghapp/ghapp/cattrs.py
@@ -3,6 +3,7 @@ import distutils.util
 
 import attr
 import cattr
+import sys
 
 def maybe_parse_bool(obj, cls):
     if isinstance(obj, (str, bytes)):
@@ -51,7 +52,11 @@ def _register_ignore_optional_none(cls, converter=None):
     prev_unstructure = converter._unstructure_func.dispatch(cls)
     optional_attrs = {
         f.name for f in attr.fields(cls)
-        if isinstance(f.type, typing._Union) and type(None) in f.type.__args__
+        if sys.version_info[0] <= 3 and sys.version_info[1] < 7:
+            if isinstance(f.type, typing._Union) and type(None) in f.type.__args__
+        else:
+            if isinstance(f.type, typing._GenericAlias) and type(None) in f.type.__args__
+            
     }
 
     def unstructure_ignoring_optional_none(obj):


### PR DESCRIPTION
in Python 3.7. typing.Tuple[int, str].__origin__ is now the class tuple, not the class typing.Tuple
which is causing issue #16 

ref https://stackoverflow.com/questions/49171189/whats-the-correct-way-to-check-if-an-object-is-a-typing-generic